### PR TITLE
QueryDsl 도입 / N+1 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,12 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    //querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect:3.2.1'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     testImplementation 'com.h2database:h2'

--- a/src/main/java/com/hyun/oauthboard/config/QueryDslConfig.java
+++ b/src/main/java/com/hyun/oauthboard/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.hyun.oauthboard.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/hyun/oauthboard/controller/BoardController.java
+++ b/src/main/java/com/hyun/oauthboard/controller/BoardController.java
@@ -1,6 +1,7 @@
 package com.hyun.oauthboard.controller;
 
 import com.hyun.oauthboard.domain.dto.board.BoardCreateRequestDto;
+import com.hyun.oauthboard.domain.dto.board.BoardIdReponse;
 import com.hyun.oauthboard.domain.dto.board.BoardResponse;
 import com.hyun.oauthboard.jwt.JwtPayload;
 import com.hyun.oauthboard.service.BoardService;
@@ -39,25 +40,26 @@ public class BoardController {
         @AuthenticationPrincipal JwtPayload jwtPayload, @PathVariable Long boardId) {
 
         BoardResponse board = boardService.readBoard(jwtPayload, boardId);
-
         return ResponseEntity.ok().body(board);
     }
 
     @PostMapping("/board")
-    public ResponseEntity<BoardResponse> writeBoard(@AuthenticationPrincipal JwtPayload jwtPayload,
+    public ResponseEntity<BoardIdReponse> writeBoard(@AuthenticationPrincipal JwtPayload jwtPayload,
         @RequestBody BoardCreateRequestDto boardCreateRequestDto) {
 
-        BoardResponse board = boardService.createBoard(jwtPayload, boardCreateRequestDto);
+        BoardIdReponse response = boardService.createBoard(jwtPayload, boardCreateRequestDto);
 
-        return ResponseEntity.ok().body(board);
+        return ResponseEntity.ok().body(response);
     }
 
     @PutMapping("/board")
-    public ResponseEntity<BoardResponse> updateBoard(@AuthenticationPrincipal JwtPayload jwtPayload,
+    public ResponseEntity<BoardIdReponse> updateBoard(
+        @AuthenticationPrincipal JwtPayload jwtPayload,
         @RequestBody BoardCreateRequestDto boardCreateRequestDto) {
-        BoardResponse board = boardService.updateBoard(jwtPayload, boardCreateRequestDto);
 
-        return ResponseEntity.ok().body(board);
+        BoardIdReponse response = boardService.updateBoard(jwtPayload, boardCreateRequestDto);
+
+        return ResponseEntity.ok().body(response);
     }
 
     @DeleteMapping("/board/{boardId}")

--- a/src/main/java/com/hyun/oauthboard/domain/dto/board/BoardIdReponse.java
+++ b/src/main/java/com/hyun/oauthboard/domain/dto/board/BoardIdReponse.java
@@ -1,0 +1,11 @@
+package com.hyun.oauthboard.domain.dto.board;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BoardIdReponse {
+
+    private Long boardId;
+}

--- a/src/main/java/com/hyun/oauthboard/domain/dto/board/BoardResponse.java
+++ b/src/main/java/com/hyun/oauthboard/domain/dto/board/BoardResponse.java
@@ -15,6 +15,8 @@ public class BoardResponse {
     private Long memberId;
     private String boardTitle;
     private String boardContent;
+    private Long views;
+    private Long likes;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime createdAt;

--- a/src/main/java/com/hyun/oauthboard/domain/entity/Board.java
+++ b/src/main/java/com/hyun/oauthboard/domain/entity/Board.java
@@ -1,10 +1,8 @@
 package com.hyun.oauthboard.domain.entity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.hyun.oauthboard.domain.dto.board.BoardCreateRequestDto;
 import com.hyun.oauthboard.domain.dto.board.BoardResponse;
 import com.hyun.oauthboard.domain.entity.model.BoardEntityModel;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -13,9 +11,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -43,16 +38,6 @@ public class Board extends BoardEntityModel {
 
     @Column(name = "board_content")
     private String boardContent;
-
-    @JsonIgnore
-    @Builder.Default
-    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<BoardLike> likes = new ArrayList<>();
-
-    @JsonIgnore
-    @Builder.Default
-    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<BoardView> views = new ArrayList<>();
 
     public void updateBoard(BoardCreateRequestDto boardCreateRequestDto) {
         this.boardTitle = boardCreateRequestDto.getBoardTitle();

--- a/src/main/java/com/hyun/oauthboard/repository/BoardCustomRepository.java
+++ b/src/main/java/com/hyun/oauthboard/repository/BoardCustomRepository.java
@@ -1,0 +1,8 @@
+package com.hyun.oauthboard.repository;
+
+import com.hyun.oauthboard.domain.dto.board.BoardResponse;
+
+public interface BoardCustomRepository {
+
+    BoardResponse findBoardLeftJoinViewsAndLikes(Long boardId);
+}

--- a/src/main/java/com/hyun/oauthboard/repository/BoardCustomRepositoryImpl.java
+++ b/src/main/java/com/hyun/oauthboard/repository/BoardCustomRepositoryImpl.java
@@ -1,0 +1,54 @@
+package com.hyun.oauthboard.repository;
+
+import static com.hyun.oauthboard.domain.entity.QBoard.board;
+import static com.hyun.oauthboard.domain.entity.QBoardLike.boardLike;
+import static com.hyun.oauthboard.domain.entity.QBoardView.boardView;
+import static com.hyun.oauthboard.domain.entity.QMember.member;
+
+import com.hyun.oauthboard.domain.dto.board.BoardResponse;
+import com.hyun.oauthboard.domain.entity.Board;
+import com.hyun.oauthboard.enums.BoardError;
+import com.hyun.oauthboard.exception.CustomException;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BoardCustomRepositoryImpl implements BoardCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public BoardResponse findBoardLeftJoinViewsAndLikes(Long boardId) {
+        Board findBoard = Optional.ofNullable(jpaQueryFactory
+            .selectFrom(board)
+            .join(board.member, member).fetchJoin()
+            .where(board.boardId.eq(boardId))
+            .fetchOne()).orElseThrow(() -> new CustomException(BoardError.BOARD_ID_NOT_EXIST));
+
+        Long likes = Optional.ofNullable(jpaQueryFactory
+            .select(boardLike.likeId.count())
+            .from(boardLike)
+            .where(boardLike.board.boardId.eq(boardId))
+            .fetchOne()).orElse(0L);
+
+        Long views = Optional.ofNullable(jpaQueryFactory
+            .select(boardView.viewId.count())
+            .from(boardView)
+            .where(boardView.board.boardId.eq(boardId))
+            .fetchOne()).orElse(0L);
+
+        return BoardResponse.builder()
+            .boardId(findBoard.getBoardId())
+            .memberId(findBoard.getMember().getMemberId())
+            .boardTitle(findBoard.getBoardTitle())
+            .boardContent(findBoard.getBoardContent())
+            .likes(likes)
+            .views(views)
+            .createdAt(findBoard.getCreatedAt())
+            .updatedAt(findBoard.getUpdatedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/hyun/oauthboard/repository/BoardRepository.java
+++ b/src/main/java/com/hyun/oauthboard/repository/BoardRepository.java
@@ -3,7 +3,7 @@ package com.hyun.oauthboard.repository;
 import com.hyun.oauthboard.domain.entity.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BoardRepository extends JpaRepository<Board, Long> {
+public interface BoardRepository extends JpaRepository<Board, Long>, BoardCustomRepository {
 
 //    @Query("SELECT DISTINCT b FROM Board b LEFT JOIN FETCH b.likes WHERE b.boardId = :boardId")
 //    Optional<Board> findById(@Param("boardId") Long boardId);

--- a/src/main/java/com/hyun/oauthboard/service/BoardService.java
+++ b/src/main/java/com/hyun/oauthboard/service/BoardService.java
@@ -1,6 +1,7 @@
 package com.hyun.oauthboard.service;
 
 import com.hyun.oauthboard.domain.dto.board.BoardCreateRequestDto;
+import com.hyun.oauthboard.domain.dto.board.BoardIdReponse;
 import com.hyun.oauthboard.domain.dto.board.BoardResponse;
 import com.hyun.oauthboard.jwt.JwtPayload;
 
@@ -8,10 +9,10 @@ public interface BoardService {
 
     BoardResponse readBoard(JwtPayload jwtPayload, Long boardId);
 
-    BoardResponse createBoard(JwtPayload jwtPayload,
+    BoardIdReponse createBoard(JwtPayload jwtPayload,
         BoardCreateRequestDto boardCreateRequestDto);
 
-    BoardResponse updateBoard(JwtPayload jwtPayload,
+    BoardIdReponse updateBoard(JwtPayload jwtPayload,
         BoardCreateRequestDto boardCreateRequestDto);
 
     void deleteBoard(JwtPayload jwtPayload, Long boardId);

--- a/src/main/java/com/hyun/oauthboard/service/BoardServiceImpl.java
+++ b/src/main/java/com/hyun/oauthboard/service/BoardServiceImpl.java
@@ -1,6 +1,7 @@
 package com.hyun.oauthboard.service;
 
 import com.hyun.oauthboard.domain.dto.board.BoardCreateRequestDto;
+import com.hyun.oauthboard.domain.dto.board.BoardIdReponse;
 import com.hyun.oauthboard.domain.dto.board.BoardResponse;
 import com.hyun.oauthboard.domain.entity.Board;
 import com.hyun.oauthboard.domain.entity.Member;
@@ -23,52 +24,49 @@ public class BoardServiceImpl implements BoardService {
     private final MemberRepository memberRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public BoardResponse readBoard(JwtPayload jwtPayload, Long boardId) {
 
-        Board board = boardRepository.findById(boardId)
-            .orElseThrow(() -> new CustomException(BoardError.BOARD_ID_NOT_EXIST));
-
-        return board.toDto();
+        return boardRepository.findBoardLeftJoinViewsAndLikes(boardId);
     }
 
-    @PreAuthorize("@securityAuthorizationBoard.checkOwner(jwtPayload.memberId, #boardCreateRequestDto.boardId)")
-    @Transactional
     @Override
-    public BoardResponse createBoard(JwtPayload jwtPayload,
+    @Transactional
+    @PreAuthorize("@securityAuthorizationBoard.checkOwner(jwtPayload.memberId, #boardCreateRequestDto.boardId)")
+    public BoardIdReponse createBoard(JwtPayload jwtPayload,
         BoardCreateRequestDto boardCreateRequestDto) {
 
         Member member = memberRepository.findById(jwtPayload.getMemberId())
             .orElseThrow(() -> new CustomException(MemberError.MEMBER_ID_NOT_EXIST));
 
-        return boardRepository.save(boardCreateRequestDto.toEntity(member)).toDto();
+        return new BoardIdReponse(
+            boardRepository.save(boardCreateRequestDto.toEntity(member)).getBoardId());
     }
 
-    @PreAuthorize("@securityAuthorizationBoard.checkOwner(jwtPayload.memberId, #boardCreateRequestDto.boardId)")
-    @Transactional
+
     @Override
-    public BoardResponse updateBoard(JwtPayload jwtPayload,
+    @Transactional
+    @PreAuthorize("@securityAuthorizationBoard.checkOwner(jwtPayload.memberId, #boardCreateRequestDto.boardId)")
+    public BoardIdReponse updateBoard(JwtPayload jwtPayload,
         BoardCreateRequestDto boardCreateRequestDto) {
 
         Board board = boardRepository.findById(
                 boardCreateRequestDto.getBoardId())
             .orElseThrow(() -> new CustomException(BoardError.BOARD_ID_NOT_EXIST));
+
         board.updateBoard(boardCreateRequestDto);
-        return board.toDto();
+
+        return new BoardIdReponse(board.getBoardId());
     }
 
-    @Transactional
-    @Override
-    public void deleteBoard(JwtPayload jwtPayload, Long boardId) {
 
-        Member member = memberRepository.findById(jwtPayload.getMemberId())
-            .orElseThrow(() -> new CustomException(MemberError.MEMBER_ID_NOT_EXIST));
+    @Override
+    @Transactional
+    @PreAuthorize("@securityAuthorizationBoard.checkOwner(jwtPayload.memberId, boardId)")
+    public void deleteBoard(JwtPayload jwtPayload, Long boardId) {
 
         Board board = boardRepository.findById(boardId)
             .orElseThrow(() -> new CustomException(BoardError.BOARD_ID_NOT_EXIST));
-
-        if (!member.getMemberId().equals(board.getMember().getMemberId())) {
-            throw new CustomException(MemberError.MEMBER_ID_MISMATCH);
-        }
 
         boardRepository.delete(board);
     }

--- a/src/test/java/com/hyun/oauthboard/QueryDslTestConfig.java
+++ b/src/test/java/com/hyun/oauthboard/QueryDslTestConfig.java
@@ -1,0 +1,15 @@
+package com.hyun.oauthboard;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class QueryDslTestConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/test/java/com/hyun/oauthboard/repository/BoardRepositoryTest.java
+++ b/src/test/java/com/hyun/oauthboard/repository/BoardRepositoryTest.java
@@ -1,16 +1,24 @@
 package com.hyun.oauthboard.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hyun.oauthboard.QueryDslTestConfig;
 import com.hyun.oauthboard.domain.entity.Board;
+import com.hyun.oauthboard.domain.entity.BoardLike;
+import com.hyun.oauthboard.domain.entity.BoardView;
 import com.hyun.oauthboard.domain.entity.Member;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("test")
 @DataJpaTest
+@Import(QueryDslTestConfig.class)
 public class BoardRepositoryTest {
+
 
     @Autowired
     private BoardRepository boardRepository;
@@ -20,6 +28,71 @@ public class BoardRepositoryTest {
 
     @Autowired
     private EntityManager em;
+
+    @Test
+    void 좋아요_조회수_연관_조회_테스트() {
+        Member writer = memberRepository.save(
+            Member.builder()
+                .memberId(1L)
+                .memberName("작성자")
+                .memberAvatar("avatar")
+                .build());
+
+        Member someone = memberRepository.save(
+            Member.builder()
+                .memberId(2L)
+                .memberName("작성자")
+                .memberAvatar("avatar")
+                .build());
+
+        Member someone2 = memberRepository.save(
+            Member.builder()
+                .memberId(3L)
+                .memberName("작성자")
+                .memberAvatar("avatar")
+                .build());
+
+        em.persist(writer);
+        em.persist(someone);
+        em.persist(someone2);
+
+        Board board = Board.builder()
+            .boardTitle("제목")
+            .boardContent("내용")
+            .member(writer)
+            .build();
+
+        em.persist(board);
+
+        BoardLike boardLike1 = BoardLike.builder()
+            .board(board)
+            .liker(someone)
+            .build();
+
+        BoardLike boardLike2 = BoardLike.builder()
+            .board(board)
+            .liker(someone2)
+            .build();
+
+        BoardView boardView = BoardView.builder()
+            .viewer(someone)
+            .board(board)
+            .build();
+
+        em.persist(boardLike1);
+        em.persist(boardLike2);
+        em.persist(boardView);
+
+        em.flush();
+        em.clear();
+
+        var response = boardRepository.findBoardLeftJoinViewsAndLikes(board.getBoardId());
+
+        assertThat(response.getBoardId()).isEqualTo(board.getBoardId());
+        assertThat(response.getViews()).isEqualTo(1L);
+        assertThat(response.getBoardTitle()).isEqualTo("제목");
+        assertThat(response.getLikes()).isEqualTo(2L);
+    }
 
     @Test
     void NPlus1_테스트() {

--- a/src/test/java/com/hyun/oauthboard/service/BoardServiceTest.java
+++ b/src/test/java/com/hyun/oauthboard/service/BoardServiceTest.java
@@ -1,0 +1,65 @@
+package com.hyun.oauthboard.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.hyun.oauthboard.domain.dto.board.BoardResponse;
+import com.hyun.oauthboard.repository.BoardRepository;
+import com.hyun.oauthboard.repository.MemberRepository;
+import java.time.LocalDateTime;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class BoardServiceTest {
+
+    @Mock
+    BoardRepository boardRepository;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @InjectMocks
+    BoardServiceImpl boardService;
+
+    @Test
+    @DisplayName("단일 게시글 조회가 성공한다")
+    void 게시글_조회_테스트() {
+        //given
+        Long boardId = 1L;
+        Long memberId = 100L;
+        BoardResponse mockResponse = BoardResponse.builder()
+            .boardId(boardId)
+            .memberId(memberId)
+            .boardTitle("테스트 제목")
+            .boardContent("테스트 내용")
+            .likes(3L)
+            .views(10L)
+            .createdAt(LocalDateTime.now())
+            .updatedAt(LocalDateTime.now())
+            .build();
+
+        given(boardRepository.findBoardLeftJoinViewsAndLikes(anyLong())).willReturn(mockResponse);
+
+        //when
+
+        BoardResponse boardResponse = boardService.readBoard(any(), boardId);
+
+        //then
+
+        Assertions.assertThat(boardResponse.getBoardId()).isEqualTo(mockResponse.getBoardId());
+        Assertions.assertThat(boardResponse.getBoardTitle())
+            .isEqualTo(mockResponse.getBoardTitle());
+
+        verify(boardRepository, times(1)).findBoardLeftJoinViewsAndLikes(anyLong());
+    }
+
+}


### PR DESCRIPTION
- queryDsl 도입
- 양방향 연관관계 제거 (Board)
- 게시판 단일 조회 테스트 코드 작성 (서비스 , 레포 단위테스트)

 - queryDsl 도입 이유?
   -  N+1 문제 해결방법을 공부 도중 ToMany 양방향 관계에서는 두번 이상의 fetchJoin 을 했을 때 `MultipleBagException` 발생
   - 따라서 양방향을 지양하고 코드를 가독성있게 구현하기 위함
   - 컴파일 단계에서 휴먼에러를 확인하기 위함

* 제대로 작성되지 않음 -> 다시 수정 필요